### PR TITLE
change to using HTTP_X_FORWARDED_FOR

### DIFF
--- a/src/BaseController.php
+++ b/src/BaseController.php
@@ -19,7 +19,7 @@ abstract class BaseController
 
     protected function getRealIP()
     {
-        return $_SERVER["REMOTE_ADDR"];
+        return $_SERVER["HTTP_X_FORWARDED_FOR"];
     }
 
     public function process($actionName)

--- a/src/Miner.php
+++ b/src/Miner.php
@@ -6,7 +6,7 @@ class Miner
 {
     protected function getRealIP()
     {
-        return $_SERVER["REMOTE_ADDR"];
+        return $_SERVER["HTTP_X_FORWARDED_FOR"];
     }
 
     public static function Current()


### PR DESCRIPTION
to get the real IPs of clients when using caddy reverse proxy

I set up a mock bfm on a local server using caddy reverse proxy, and using this change allows the real IPs of miners and users to be added to the SQL tables, and doesn't break anything that I tested.